### PR TITLE
refactor: :recycle: remove struts-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
 	<properties>
 
 		<!-- Plugins property -->
-		<maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-		<swagger-ui.version>3.23.5</swagger-ui.version>
-		<maven-war-plugin.version>3.2.2</maven-war-plugin.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<maven-download-plugin.version>1.2.1</maven-download-plugin.version>
+		<swagger-ui.version>4.5.0</swagger-ui.version>
+		<maven-war-plugin.version>3.3.2</maven-war-plugin.version>
 		<replacer.version>1.5.3</replacer.version>
 		<swagger-maven-plugin.version>3.1.1</swagger-maven-plugin.version>
-		<exec-maven-plugin.version>1.3.2</exec-maven-plugin.version>
-		<openapi-generator-cli.version>4.0.3</openapi-generator-cli.version>
+		<exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+		<openapi-generator-cli.version>5.4.0</openapi-generator-cli.version>
 
 		<!-- Project property -->
 		<war-name>activity-api</war-name>
@@ -227,24 +227,20 @@
 			</plugin>
 
 			<plugin>
-				<!-- Download Swagger UI webjar. -->
-				<artifactId>maven-dependency-plugin</artifactId>
-				<version>${maven-dependency-plugin.version}</version>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>${maven-download-plugin.version}</version>
 				<executions>
 					<execution>
+						<id>swagger-ui</id>
 						<phase>prepare-package</phase>
 						<goals>
-							<goal>unpack</goal>
+							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.webjars</groupId>
-									<artifactId>swagger-ui</artifactId>
-									<version>${swagger-ui.version}</version>
-								</artifactItem>
-							</artifactItems>
-							<outputDirectory> ${project.build.directory}/swagger-ui</outputDirectory>
+							<url>https://github.com/swagger-api/swagger-ui/archive/v${swagger-ui.version}.tar.gz</url>
+							<unpack>true</unpack>
+							<outputDirectory>${project.build.directory}</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>
@@ -256,7 +252,7 @@
 				<configuration>
 					<webResources combine.children="append">
 						<resource>
-							<directory>${project.build.directory}/swagger-ui/META-INF/resources/webjars/swagger-ui/${swagger-ui.version}</directory>
+							<directory>${project.build.directory}/swagger-ui-${swagger-ui.version}/dist</directory>
 							<includes>
 								<include>**/*.*</include>
 							</includes>
@@ -282,7 +278,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<file>${project.build.directory}/swagger-ui/META-INF/resources/webjars/swagger-ui/${swagger-ui.version}/index.html</file>
+					<file>${project.build.directory}/swagger-ui-${swagger-ui.version}/dist/index.html</file>
 					<replacements>
 						<replacement>
 							<token>https://petstore.swagger.io/v2/swagger.json</token>


### PR DESCRIPTION
- replace maven dependency plugin with maven download plugin that doesn't use `struts-core@1.3.x`
- updates openapi generator from 4.x to 5.x since javadoc plugin in 4.x had sub dependency of `struts-core`